### PR TITLE
Bugfix

### DIFF
--- a/include/yampi/algorithm/all_of.hpp
+++ b/include/yampi/algorithm/all_of.hpp
@@ -28,7 +28,12 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
-      bool result = std::all_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate);
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      bool result = std::all_of(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       if (communicator.rank(environment) == root)
       {
@@ -50,8 +55,13 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
-        ::yampi::make_buffer(std::all_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate)),
+        ::yampi::make_buffer(std::all_of(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::logical_and_t()),
         communicator, environment);
     }
@@ -65,8 +75,13 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const& root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       bool result
-        = std::all_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate);
+        = std::all_of(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       ::yampi::reduce const reducer(root, communicator);
 
@@ -93,9 +108,14 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         request,
-        ::yampi::make_buffer(std::all_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate)),
+        ::yampi::make_buffer(std::all_of(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::logical_and_t()),
         communicator, environment);
     }

--- a/include/yampi/algorithm/any_of.hpp
+++ b/include/yampi/algorithm/any_of.hpp
@@ -28,7 +28,12 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
-      bool result = std::any_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate);
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      bool result = std::any_of(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       if (communicator.rank(environment) == root)
       {
@@ -50,8 +55,13 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
-        ::yampi::make_buffer(std::any_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate)),
+        ::yampi::make_buffer(std::any_of(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::logical_or_t()),
         communicator, environment);
     }
@@ -65,8 +75,13 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const& root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       bool result
-        = std::any_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate);
+        = std::any_of(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       ::yampi::reduce const reducer(root, communicator);
 
@@ -93,9 +108,14 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         request,
-        ::yampi::make_buffer(std::any_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate)),
+        ::yampi::make_buffer(std::any_of(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::logical_or_t()),
         communicator, environment);
     }

--- a/include/yampi/algorithm/count.hpp
+++ b/include/yampi/algorithm/count.hpp
@@ -31,8 +31,13 @@ namespace yampi
       Value const& value, ::yampi::rank const root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       typedef typename std::iterator_traits<Value const*>::difference_type count_type;
-      count_type result = std::count(buffer.data(), buffer.data() + buffer.count(), value);
+      count_type result = std::count(buffer.data(), buffer.data() + buffer_size, value);
 
       if (communicator.rank(environment) == root)
       {
@@ -55,9 +60,14 @@ namespace yampi
       Value const& value,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         ::yampi::make_buffer(
-          std::count(buffer.data(), buffer.data() + buffer.count(), value)),
+          std::count(buffer.data(), buffer.data() + buffer_size, value)),
         ::yampi::binary_operation(::yampi::plus_t()),
         communicator, environment);
     }
@@ -73,9 +83,14 @@ namespace yampi
       Value const& value, ::yampi::rank const& root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       typedef typename std::iterator_traits<Value const*>::difference_type count_type;
       count_type result
-        = std::count(buffer.data(), buffer.data() + buffer.count(), value);
+        = std::count(buffer.data(), buffer.data() + buffer_size, value);
 
       ::yampi::reduce const reducer(root, communicator);
 
@@ -103,9 +118,14 @@ namespace yampi
       Value const& value,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         request,
-        ::yampi::make_buffer(std::count(buffer.data(), buffer.data() + buffer.count(), value)),
+        ::yampi::make_buffer(std::count(buffer.data(), buffer.data() + buffer_size, value)),
         ::yampi::binary_operation(::yampi::plus_t()),
         communicator, environment);
     }

--- a/include/yampi/algorithm/count_if.hpp
+++ b/include/yampi/algorithm/count_if.hpp
@@ -31,8 +31,13 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       typedef typename std::iterator_traits<Value const*>::difference_type count_type;
-      count_type result = std::count_if(buffer.data(), buffer.data() + buffer.count_if(), unary_predicate);
+      count_type result = std::count_if(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       if (communicator.rank(environment) == root)
       {
@@ -55,9 +60,14 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         ::yampi::make_buffer(
-          std::count_if(buffer.data(), buffer.data() + buffer.count_if(), unary_predicate)),
+          std::count_if(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::plus_t()),
         communicator, environment);
     }
@@ -73,9 +83,14 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const& root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       typedef typename std::iterator_traits<Value const*>::difference_type count_type;
       count_type result
-        = std::count_if(buffer.data(), buffer.data() + buffer.count_if(), unary_predicate);
+        = std::count_if(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       ::yampi::reduce const reducer(root, communicator);
 
@@ -103,9 +118,14 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         request,
-        ::yampi::make_buffer(std::count_if(buffer.data(), buffer.data() + buffer.count_if(), unary_predicate)),
+        ::yampi::make_buffer(std::count_if(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::plus_t()),
         communicator, environment);
     }

--- a/include/yampi/algorithm/max_element.hpp
+++ b/include/yampi/algorithm/max_element.hpp
@@ -40,8 +40,13 @@ namespace yampi
       ::yampi::datatype const& value_int_datatype,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       Value const* max_value_ptr
-        = std::max_element(buffer.data(), buffer.data() + buffer.count());
+        = std::max_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank = std::make_pair(*max_value_ptr, present_rank.mpi_rank());
@@ -77,8 +82,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::rank const root,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       Value const* max_value_ptr
-        = std::max_element(buffer.data(), buffer.data() + buffer.count());
+        = std::max_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank = std::make_pair(*max_value_ptr, present_rank.mpi_rank());
@@ -133,7 +143,12 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::datatype const& value_int_datatype,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
-      Value const* max_value_ptr = std::max_element(buffer.data(), buffer.data() + buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      Value const* max_value_ptr = std::max_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank = std::make_pair(*max_value_ptr, present_rank.mpi_rank());
@@ -158,7 +173,12 @@ namespace yampi
       ::yampi::buffer<Value> const buffer,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
-      Value const* max_value_ptr = std::max_element(buffer.data(), buffer.data() + buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      Value const* max_value_ptr = std::max_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank = std::make_pair(*max_value_ptr, present_rank.mpi_rank());

--- a/include/yampi/algorithm/min_element.hpp
+++ b/include/yampi/algorithm/min_element.hpp
@@ -40,7 +40,12 @@ namespace yampi
       ::yampi::datatype const& value_int_datatype,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
-      Value const* min_value_ptr = std::min_element(buffer.data(), buffer.data() + buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      Value const* min_value_ptr = std::min_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank = std::make_pair(*min_value_ptr, present_rank.mpi_rank());
@@ -76,7 +81,12 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::rank const root,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
-      Value const* min_value_ptr = std::min_element(buffer.data(), buffer.data() + buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      Value const* min_value_ptr = std::min_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank = std::make_pair(*min_value_ptr, present_rank.mpi_rank());
@@ -131,8 +141,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::datatype const& value_int_datatype,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       Value const* min_value_ptr
-        = std::min_element(buffer.data(), buffer.data() + buffer.count());
+        = std::min_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank
@@ -158,8 +173,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       Value const* min_value_ptr
-        = std::min_element(buffer.data(), buffer.data() + buffer.count());
+        = std::min_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       std::pair<Value, int> value_rank

--- a/include/yampi/algorithm/minmax_element.hpp
+++ b/include/yampi/algorithm/minmax_element.hpp
@@ -44,8 +44,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::rank const root, ::yampi::datatype const& value_int_datatype,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       std::pair<Value const*, Value const*> minmax_value_ptrs
-        = std::minmax_element(buffer.data(), buffer.data() + buffer.count());
+        = std::minmax_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       // min_element
@@ -108,8 +113,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::rank const root,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       std::pair<Value const*, Value const*> minmax_value_ptrs
-        = std::minmax_element(buffer.data(), buffer.data() + buffer.count());
+        = std::minmax_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       // min_element
@@ -195,8 +205,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer, ::yampi::datatype const& value_int_datatype,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       std::pair<Value const*, Value const*> minmax_value_ptrs
-        = std::minmax_element(buffer.data(), buffer.data() + buffer.count());
+        = std::minmax_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       // min_element
@@ -239,8 +254,13 @@ namespace yampi
       ::yampi::buffer<Value> const buffer,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       std::pair<Value const*, Value const*> minmax_value_ptrs
-        = std::minmax_element(buffer.data(), buffer.data() + buffer.count());
+        = std::minmax_element(buffer.data(), buffer.data() + buffer_size);
       ::yampi::rank const present_rank = communicator.rank(environment);
 
       // min_element

--- a/include/yampi/algorithm/none_of.hpp
+++ b/include/yampi/algorithm/none_of.hpp
@@ -28,7 +28,12 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
-      bool result = std::none_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate);
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
+      bool result = std::none_of(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       if (communicator.rank(environment) == root)
       {
@@ -50,9 +55,14 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         ::yampi::make_buffer(
-          std::none_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate)),
+          std::none_of(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::logical_and_t()),
         communicator, environment);
     }
@@ -66,8 +76,13 @@ namespace yampi
       UnaryPredicate unary_predicate, ::yampi::rank const& root,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       bool result
-        = std::none_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate);
+        = std::none_of(buffer.data(), buffer.data() + buffer_size, unary_predicate);
 
       ::yampi::reduce const reducer(root, communicator);
 
@@ -94,9 +109,14 @@ namespace yampi
       UnaryPredicate unary_predicate,
       ::yampi:communicator const& communicator, ::yampi::environment const& environment)
     {
+# if MPI_VERSION >= 4
+      auto const buffer_size = buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = buffer.count();
+# endif // MPI_VERSION >= 4
       return ::yampi::all_reduce(
         request,
-        ::yampi::make_buffer(std::none_of(buffer.data(), buffer.data() + buffer.count(), unary_predicate)),
+        ::yampi::make_buffer(std::none_of(buffer.data(), buffer.data() + buffer_size, unary_predicate)),
         ::yampi::binary_operation(::yampi::logical_and_t()),
         communicator, environment);
     }

--- a/include/yampi/algorithm/replace_copy.hpp
+++ b/include/yampi/algorithm/replace_copy.hpp
@@ -46,13 +46,18 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_buffer_first, old_value, new_value);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            replace_copy_buffer_first, replace_copy_buffer_first + send_buffer.count(),
+            replace_copy_buffer_first, replace_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -69,7 +74,12 @@ namespace yampi
       Value const& old_value, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(buffer_size);
       return ::yampi::algorithm::replace_copy(
         send_buffer, receive_buffer, old_value, new_value,
         replace_copy_buffer.begin(), message_envelope, environment);
@@ -99,14 +109,19 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_buffer_first, old_value, new_value);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            replace_copy_buffer_first, replace_copy_buffer_first + send_buffer.count(),
+            replace_copy_buffer_first, replace_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -124,7 +139,12 @@ namespace yampi
       Value const& old_value, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(buffer_size);
       return ::yampi::algorithm::replace_copy(
         std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer, old_value, new_value,
@@ -155,13 +175,18 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_buffer_first, old_value, new_value);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            replace_copy_buffer_first, replace_copy_buffer_first + send_buffer.count(),
+            replace_copy_buffer_first, replace_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -176,7 +201,12 @@ namespace yampi
       Value const& old_value, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(buffer_size);
       ::yampi::algorithm::replace_copy(
         ignore_status,
         send_buffer, receive_buffer, old_value, new_value,
@@ -207,14 +237,19 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_buffer_first, old_value, new_value);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            replace_copy_buffer_first, replace_copy_buffer_first + send_buffer.count(),
+            replace_copy_buffer_first, replace_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -230,7 +265,12 @@ namespace yampi
       Value const& old_value, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_buffer(buffer_size);
       ::yampi::algorithm::replace_copy(
         ignore_status, std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer, old_value, new_value,

--- a/include/yampi/algorithm/replace_copy_if.hpp
+++ b/include/yampi/algorithm/replace_copy_if.hpp
@@ -46,13 +46,18 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy_if(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_if_buffer_first, predicate, new_value);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            replace_copy_if_buffer_first, replace_copy_if_buffer_first + send_buffer.count(),
+            replace_copy_if_buffer_first, replace_copy_if_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -69,7 +74,12 @@ namespace yampi
       UnaryPredicate predicate, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(buffer_size);
       return ::yampi::algorithm::replace_copy_if(
         send_buffer, receive_buffer, predicate, new_value,
         replace_copy_if_buffer.begin(), message_envelope, environment);
@@ -99,14 +109,19 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy_if(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_if_buffer_first, predicate, new_value);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            replace_copy_if_buffer_first, replace_copy_if_buffer_first + send_buffer.count(),
+            replace_copy_if_buffer_first, replace_copy_if_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -124,7 +139,12 @@ namespace yampi
       UnaryPredicate predicate, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(buffer_size);
       return ::yampi::algorithm::replace_copy_if(
         std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer, predicate, new_value,
@@ -155,13 +175,18 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy_if(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_if_buffer_first, predicate, new_value);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            replace_copy_if_buffer_first, replace_copy_if_buffer_first + send_buffer.count(),
+            replace_copy_if_buffer_first, replace_copy_if_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -176,7 +201,12 @@ namespace yampi
       UnaryPredicate predicate, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(buffer_size);
       ::yampi::algorithm::replace_copy_if(
         ignore_status,
         send_buffer, receive_buffer, predicate, new_value,
@@ -207,14 +237,19 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::replace_copy_if(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           replace_copy_if_buffer_first, predicate, new_value);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            replace_copy_if_buffer_first, replace_copy_if_buffer_first + send_buffer.count(),
+            replace_copy_if_buffer_first, replace_copy_if_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -230,7 +265,12 @@ namespace yampi
       UnaryPredicate predicate, Value const& new_value,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > replace_copy_if_buffer(buffer_size);
       ::yampi::algorithm::replace_copy_if(
         ignore_status, std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer, predicate, new_value,

--- a/include/yampi/algorithm/reverse_copy.hpp
+++ b/include/yampi/algorithm/reverse_copy.hpp
@@ -45,13 +45,18 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::reverse_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           reverse_copy_buffer_first);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            reverse_copy_buffer_first, reverse_copy_buffer_first + send_buffer.count(),
+            reverse_copy_buffer_first, reverse_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -67,7 +72,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(buffer_size);
       return ::yampi::algorithm::reverse_copy(
         send_buffer, receive_buffer,
         reverse_copy_buffer.begin(), message_envelope, environment);
@@ -96,14 +106,19 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::reverse_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           reverse_copy_buffer_first);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            reverse_copy_buffer_first, reverse_copy_buffer_first + send_buffer.count(),
+            reverse_copy_buffer_first, reverse_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -120,7 +135,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(buffer_size);
       return ::yampi::algorithm::reverse_copy(
         std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer,
@@ -150,13 +170,18 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::reverse_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           reverse_copy_buffer_first);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            reverse_copy_buffer_first, reverse_copy_buffer_first + send_buffer.count(),
+            reverse_copy_buffer_first, reverse_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -170,7 +195,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(buffer_size);
       ::yampi::algorithm::reverse_copy(
         ignore_status,
         send_buffer, receive_buffer,
@@ -200,14 +230,19 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::reverse_copy(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           reverse_copy_buffer_first);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            reverse_copy_buffer_first, reverse_copy_buffer_first + send_buffer.count(),
+            reverse_copy_buffer_first, reverse_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -222,7 +257,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > reverse_copy_buffer(buffer_size);
       ::yampi::algorithm::reverse_copy(
         ignore_status, std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer,

--- a/include/yampi/algorithm/rotate_copy.hpp
+++ b/include/yampi/algorithm/rotate_copy.hpp
@@ -32,7 +32,11 @@ namespace yampi
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
       assert(send_buffer.count() == receive_buffer.count());
+# if MPI_VERSION >= 4
+      assert(n >= 0 and n < send_buffer.count().mpi_count());
+# else // MPI_VERSION >= 4
       assert(n >= 0 and n < send_buffer.count());
+# endif // MPI_VERSION >= 4
 
       if (message_envelope.source() == message_envelope.destination())
         return boost::none;
@@ -46,13 +50,18 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::rotate_copy(
-          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + buffer_size,
           rotate_copy_buffer_first);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            rotate_copy_buffer_first, rotate_copy_buffer_first + send_buffer.count(),
+            rotate_copy_buffer_first, rotate_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -68,7 +77,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(buffer_size);
       return ::yampi::algorithm::rotate_copy(
         send_buffer, receive_buffer,
         rotate_copy_buffer.begin(), message_envelope, environment);
@@ -84,7 +98,11 @@ namespace yampi
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
       assert(send_buffer.count() == receive_buffer.count());
+# if MPI_VERSION >= 4
+      assert(n >= 0 and n < send_buffer.count().mpi_count());
+# else // MPI_VERSION >= 4
       assert(n >= 0 and n < send_buffer.count());
+# endif // MPI_VERSION >= 4
 
       if (message_envelope.source() == message_envelope.destination())
         return boost::none;
@@ -98,14 +116,19 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::rotate_copy(
-          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + buffer_size,
           rotate_copy_buffer_first);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            rotate_copy_buffer_first, rotate_copy_buffer_first + send_buffer.count(),
+            rotate_copy_buffer_first, rotate_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -122,7 +145,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(buffer_size);
       return ::yampi::algorithm::rotate_copy(
         std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer,
@@ -139,7 +167,11 @@ namespace yampi
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
       assert(send_buffer.count() == receive_buffer.count());
+# if MPI_VERSION >= 4
+      assert(n >= 0 and n < send_buffer.count().mpi_count());
+# else // MPI_VERSION >= 4
       assert(n >= 0 and n < send_buffer.count());
+# endif // MPI_VERSION >= 4
 
       if (message_envelope.source() == message_envelope.destination())
         return;
@@ -153,13 +185,18 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::rotate_copy(
-          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + buffer_size,
           rotate_copy_buffer_first);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            rotate_copy_buffer_first, rotate_copy_buffer_first + send_buffer.count(),
+            rotate_copy_buffer_first, rotate_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -173,7 +210,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(buffer_size);
       ::yampi::algorithm::rotate_copy(
         ignore_status,
         send_buffer, receive_buffer,
@@ -190,7 +232,11 @@ namespace yampi
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
       assert(send_buffer.count() == receive_buffer.count());
+# if MPI_VERSION >= 4
+      assert(n >= 0 and n < send_buffer.count().mpi_count());
+# else // MPI_VERSION >= 4
       assert(n >= 0 and n < send_buffer.count());
+# endif // MPI_VERSION >= 4
 
       if (message_envelope.source() == message_envelope.destination())
         return;
@@ -204,14 +250,19 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::rotate_copy(
-          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + n, send_buffer.data() + buffer_size,
           rotate_copy_buffer_first);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            rotate_copy_buffer_first, rotate_copy_buffer_first + send_buffer.count(),
+            rotate_copy_buffer_first, rotate_copy_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -226,7 +277,12 @@ namespace yampi
       ::yampi::buffer<Value> receive_buffer,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > rotate_copy_buffer(buffer_size);
       ::yampi::algorithm::rotate_copy(
         ignore_status, std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer,

--- a/include/yampi/algorithm/transform.hpp
+++ b/include/yampi/algorithm/transform.hpp
@@ -44,13 +44,18 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::transform(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           transform_buffer_first, unary_function);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            transform_buffer_first, transform_buffer_first + send_buffer.count(),
+            transform_buffer_first, transform_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -66,7 +71,12 @@ namespace yampi
       UnaryFunction unary_function,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(buffer_size);
       return ::yampi::algorithm::transform(
         send_buffer, receive_buffer, unary_function, transform_buffer.begin(), message_envelope, environment);
     }
@@ -93,14 +103,19 @@ namespace yampi
             message_envelope.communicator(), environment));
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::transform(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           transform_buffer_first, unary_function);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            transform_buffer_first, transform_buffer_first + send_buffer.count(),
+            transform_buffer_first, transform_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -117,7 +132,12 @@ namespace yampi
       UnaryFunction unary_function,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(buffer_size);
       return ::yampi::algorithm::transform(
         std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer, unary_function, transform_buffer.begin(), message_envelope, environment);
@@ -145,13 +165,18 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::transform(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           transform_buffer_first, unary_function);
 
         ::yampi::send(
           ::yampi::make_buffer(
-            transform_buffer_first, transform_buffer_first + send_buffer.count(),
+            transform_buffer_first, transform_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -166,7 +191,7 @@ namespace yampi
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
 # if MPI_VERSION >= 4
-      auto const buffer_size = send_buffer.count().int_mpi_count();
+      auto const buffer_size = send_buffer.count().mpi_count();
 # else // MPI_VERSION >= 4
       auto const buffer_size = send_buffer.count();
 # endif // MPI_VERSION >= 4
@@ -197,14 +222,19 @@ namespace yampi
           message_envelope.communicator(), environment);
       else if (present_rank == message_envelope.source())
       {
+# if MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+        auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
         std::transform(
-          send_buffer.data(), send_buffer.data() + send_buffer.count(),
+          send_buffer.data(), send_buffer.data() + buffer_size,
           transform_buffer_first, unary_function);
 
         ::yampi::send(
           std::forward<CommunicationMode>(communication_mode),
           ::yampi::make_buffer(
-            transform_buffer_first, transform_buffer_first + send_buffer.count(),
+            transform_buffer_first, transform_buffer_first + buffer_size,
             send_buffer.datatype()),
           message_envelope.destination(), message_envelope.tag(),
           message_envelope.communicator(), environment);
@@ -219,7 +249,12 @@ namespace yampi
       UnaryFunction unary_function,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(buffer_size);
       ::yampi::algorithm::transform(
         ignore_status, std::forward<CommunicationMode>(communication_mode),
         send_buffer, receive_buffer, unary_function,

--- a/include/yampi/algorithm/transform.hpp
+++ b/include/yampi/algorithm/transform.hpp
@@ -165,7 +165,12 @@ namespace yampi
       UnaryFunction unary_function,
       ::yampi::message_envelope const message_envelope, ::yampi::environment const& environment)
     {
-      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(send_buffer.count());
+# if MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count().int_mpi_count();
+# else // MPI_VERSION >= 4
+      auto const buffer_size = send_buffer.count();
+# endif // MPI_VERSION >= 4
+      std::vector<Value, ::yampi::allocator<Value> > transform_buffer(buffer_size);
       ::yampi::algorithm::transform(
         ignore_status, send_buffer, receive_buffer, unary_function, transform_buffer.begin(), message_envelope, environment);
     }

--- a/include/yampi/all_gather.hpp
+++ b/include/yampi/all_gather.hpp
@@ -33,7 +33,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.size(environment) <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.size(environment) <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -63,7 +67,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
     ::yampi::communicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
     auto const size = communicator.size(environment);
     auto const receive_count = receive_buffer.count() / size;
@@ -130,7 +138,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.remote_size(environment) <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.remote_size(environment) <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -160,7 +172,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
     ::yampi::intercommunicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
     auto const remote_size = communicator.remote_size(environment);
     auto const receive_count = receive_buffer.count() / remote_size;
@@ -201,7 +217,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * topology.num_neighbors(environment) <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * topology.num_neighbors(environment) <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -225,7 +245,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
     ::yampi::topology<Topology> const& topology, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
     auto const num_neighbors = topology.num_neighbors(environment);
     auto const receive_count = receive_buffer.count() / num_neighbors;

--- a/include/yampi/all_reduce.hpp
+++ b/include/yampi/all_reduce.hpp
@@ -31,7 +31,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -62,7 +66,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::binary_operation const& operation,
     ::yampi::communicator_base const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.count().mpi_count() == 1);
+# else // MPI_VERSION >= 4
     assert(send_buffer.count() == 1);
+# endif // MPI_VERSION >= 4
 
     SendValue result;
     ::yampi::all_reduce(send_buffer, &result, operation, communicator, environment);

--- a/include/yampi/binary_operation.hpp
+++ b/include/yampi/binary_operation.hpp
@@ -238,6 +238,15 @@ namespace yampi
 # undef YAMPI_DEFINE_OPERATION_RESET
 
     // TODO: Implement something like yampi::function
+# if MPI_VERSION >= 4
+    void reset(
+      MPI_User_function_c* mpi_user_function, bool const is_commutative,
+      ::yampi::environment const& environment)
+    {
+      free(environment);
+      mpi_op_ = create(mpi_user_function, is_commutative, environment);
+    }
+# else // MPI_VERSION >= 4
     void reset(
       MPI_User_function* mpi_user_function, bool const is_commutative,
       ::yampi::environment const& environment)
@@ -245,6 +254,7 @@ namespace yampi
       free(environment);
       mpi_op_ = create(mpi_user_function, is_commutative, environment);
     }
+# endif // MPI_VERSION >= 4
 
     void free(::yampi::environment const& environment)
     {

--- a/include/yampi/complete_exchange.hpp
+++ b/include/yampi/complete_exchange.hpp
@@ -33,7 +33,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.size(environment) <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.size(environment) <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -63,7 +67,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
     ::yampi::communicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
     auto const size = communicator.size(environment);
     auto const receive_count = receive_buffer.count() / size;
@@ -130,7 +138,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.remote_size(environment) <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.remote_size(environment) <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -160,7 +172,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
     ::yampi::intercommunicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
     auto const remote_size = communicator.remote_size(environment);
     auto const receive_count = receive_buffer.count() / remote_size;
@@ -201,7 +217,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * topology.num_neighbors(environment) <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * topology.num_neighbors(environment) <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -225,7 +245,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
     ::yampi::topology<Topology> const& topology, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
     auto const num_neighbors = topology.num_neighbors(environment);
     auto const receive_count = receive_buffer.count() / num_neighbors;

--- a/include/yampi/exclusive_scan.hpp
+++ b/include/yampi/exclusive_scan.hpp
@@ -30,7 +30,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -62,7 +66,11 @@ namespace yampi
     ::yampi::binary_operation const& operation,
     ::yampi::communicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.count().mpi_count() == 1);
+# else // MPI_VERSION >= 4
     assert(send_buffer.count() == 1);
+# endif // MPI_VERSION >= 4
 
     SendValue result;
     ::yampi::exclusive_scan(send_buffer, &result, operation, communicator, environment);

--- a/include/yampi/extent.hpp
+++ b/include/yampi/extent.hpp
@@ -35,6 +35,7 @@ namespace yampi
     ~extent() noexcept = default;
 
 # if MPI_VERSION >= 3
+    template <std::enable_if<not std::is_same<MPI_Aint, MPI_Count>::value, bool>::type = true>
     explicit constexpr extent(MPI_Aint const& mpi_extent) noexcept
       : mpi_extent_{static_cast<MPI_Count>(mpi_extent)}
     { }

--- a/include/yampi/extent.hpp
+++ b/include/yampi/extent.hpp
@@ -35,16 +35,21 @@ namespace yampi
     ~extent() noexcept = default;
 
 # if MPI_VERSION >= 3
-    template <std::enable_if<not std::is_same<MPI_Aint, MPI_Count>::value, bool>::type = true>
-    explicit constexpr extent(MPI_Aint const& mpi_extent) noexcept
-      : mpi_extent_{static_cast<MPI_Count>(mpi_extent)}
+    template <typename Extent>
+    explicit constexpr extent(Extent const& mpi_extent) noexcept
+      : mpi_extent_{to_mpi_count<>::call(mpi_extent)}
     { }
 
-    explicit constexpr extent(MPI_Count const& mpi_extent)
-      noexcept(std::is_nothrow_copy_constructible<MPI_Count>::value)
-      : mpi_extent_{mpi_extent}
-    { }
+   private:
+    template <typename MpiAint = MPI_Aint, typename MpiCount = MPI_Count>
+    struct to_mpi_count
+    { static MpiCount call(MpiAint const& mpi_extent) { return static_cast<MpiCount>(mpi_extent); } };
 
+    template <typename MpiCount>
+    struct to_mpi_count<MpiCount, MpiCount>
+    { static MpiCount call(MpiCount const& mpi_extent) { return mpi_extent; } };
+
+   public:
     constexpr MPI_Count const& mpi_extent() const { return mpi_extent_; }
     constexpr MPI_Aint mpi_aint_mpi_extent() const { return static_cast<MPI_Aint>(mpi_extent_); }
 

--- a/include/yampi/gather.hpp
+++ b/include/yampi/gather.hpp
@@ -32,7 +32,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.size(environment) <= send_buffer.data()));
+# else // MPI_VERSION >= 4
     assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.size(environment) <= send_buffer.data()));
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -62,7 +66,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer, ::yampi::rank const root,
     ::yampi::communicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data()));
+# else // MPI_VERSION >= 4
     assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data()));
+# endif // MPI_VERSION >= 4
 
     auto const size = communicator.size(environment);
     auto const receive_count = receive_buffer.count() / size;

--- a/include/yampi/immediate_request.hpp
+++ b/include/yampi/immediate_request.hpp
@@ -324,7 +324,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.size(environment) <= send_buffer.data()));
+#   else // MPI_VERSION >= 4
       assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.size(environment) <= send_buffer.data()));
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -349,7 +353,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer, ::yampi::rank const root,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data()));
+#   else // MPI_VERSION >= 4
       assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data()));
+#   endif // MPI_VERSION >= 4
 
       auto const size = communicator.size(environment);
       auto const receive_count = receive_buffer.count() / size;
@@ -662,7 +670,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            ReceiveValue>::value),
         "value_type of ContiguousIterator must be the same to ReceiveValue");
+#   if MPI_VERSION >= 4
+      assert(communicator.rank(environment) != root or (std::addressof(*first) + receive_buffer.count().mpi_count() * communicator.size(environment) <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= std::addressof(*first)));
+#   else // MPI_VERSION >= 4
       assert(communicator.rank(environment) != root or (std::addressof(*first) + receive_buffer.count() * communicator.size(environment) <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= std::addressof(*first)));
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -687,7 +699,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer, ::yampi::rank const root,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data()));
+#   else // MPI_VERSION >= 4
       assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data()));
+#   endif // MPI_VERSION >= 4
 
       auto const size = communicator.size(environment);
       auto const send_count = send_buffer.count() / size;
@@ -1000,7 +1016,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.size(environment) <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.size(environment) <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1025,7 +1045,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
       auto const size = communicator.size(environment);
       auto const receive_count = receive_buffer.count() / size;
@@ -1086,7 +1110,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.remote_size(environment) <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.remote_size(environment) <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1111,7 +1139,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
       ::yampi::intercommunicator const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
       auto const remote_size = communicator.remote_size(environment);
       auto const receive_count = receive_buffer.count() / remote_size;
@@ -1146,7 +1178,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * topology.num_neighbors(environment) <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * topology.num_neighbors(environment) <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1171,7 +1207,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
       ::yampi::topology<Topology> const& topology, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
       auto const num_neighbors = topology.num_neighbors(environment);
       auto const receive_count = receive_buffer.count() / num_neighbors;
@@ -1289,7 +1329,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.size(environment) <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.size(environment) <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1314,7 +1358,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
       ::yampi::communicator const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
       auto const size = communicator.size(environment);
       auto const receive_count = receive_buffer.count() / size;
@@ -1375,7 +1423,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * communicator.remote_size(environment) <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * communicator.remote_size(environment) <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1400,7 +1452,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
       ::yampi::intercommunicator const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
       auto const remote_size = communicator.remote_size(environment);
       auto const receive_count = receive_buffer.count() / remote_size;
@@ -1435,7 +1491,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() * topology.num_neighbors(environment) <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() * topology.num_neighbors(environment) <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1460,7 +1520,11 @@ namespace yampi
       ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer,
       ::yampi::topology<Topology> const& topology, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
       auto const num_neighbors = topology.num_neighbors(environment);
       auto const receive_count = receive_buffer.count() / num_neighbors;
@@ -1680,7 +1744,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1850,7 +1918,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1906,8 +1978,13 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to Value");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + 1 <= send_buffer.data());
+      assert(send_buffer.count().mpi_count() == communicator.size(environment));
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + 1 <= send_buffer.data());
       assert(send_buffer.count() == communicator.size(environment));
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -1931,8 +2008,13 @@ namespace yampi
       ::yampi::binary_operation const& operation,
       ::yampi::communicator_base const& communicator, ::yampi::environment const& environment)
     {
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+      assert(send_buffer.count().mpi_count() == communicator.size(environment) * receive_buffer.count().mpi_count());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
       assert(send_buffer.count() == communicator.size(environment) * receive_buffer.count());
+#   endif // MPI_VERSION >= 4
       assert(send_buffer.datatype() == receive_buffer.datatype());
 
 #   if MPI_VERSION >= 4
@@ -1989,7 +2071,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code
@@ -2043,7 +2129,11 @@ namespace yampi
            typename std::iterator_traits<ContiguousIterator>::value_type,
            SendValue>::value),
         "value_type of ContiguousIterator must be the same to SendValue");
+#   if MPI_VERSION >= 4
+      assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+#   else // MPI_VERSION >= 4
       assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+#   endif // MPI_VERSION >= 4
 
 #   if MPI_VERSION >= 4
       auto const error_code

--- a/include/yampi/inclusive_scan.hpp
+++ b/include/yampi/inclusive_scan.hpp
@@ -30,7 +30,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -62,7 +66,11 @@ namespace yampi
     ::yampi::binary_operation const& operation,
     ::yampi::communicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.count().mpi_count() == 1);
+# else // MPI_VERSION >= 4
     assert(send_buffer.count() == 1);
+# endif // MPI_VERSION >= 4
 
     SendValue result;
     ::yampi::inclusive_scan(send_buffer, &result, operation, communicator, environment);

--- a/include/yampi/information.hpp
+++ b/include/yampi/information.hpp
@@ -184,7 +184,7 @@ namespace yampi
       error_code
         = MPI_Info_get_string(
             mpi_info_, key.c_str(),
-            buffer_length, const_cast<char*>(result.c_str()), std::addressof(flag));
+            std::addressof(buffer_length), const_cast<char*>(result.c_str()), std::addressof(flag));
       if (error_code != MPI_SUCCESS)
         throw ::yampi::error(error_code, "yampi::information::at", environment);
 

--- a/include/yampi/persistent_request.hpp
+++ b/include/yampi/persistent_request.hpp
@@ -126,7 +126,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Send_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             std::addressof(mpi_request));
 # elif MPI_VERSION >= 3
@@ -165,7 +165,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Bsend_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             std::addressof(mpi_request));
 # elif MPI_VERSION >= 3
@@ -204,7 +204,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Ssend_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             std::addressof(mpi_request));
 # elif MPI_VERSION >= 3
@@ -243,7 +243,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Rsend_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             std::addressof(mpi_request));
 # elif MPI_VERSION >= 3
@@ -283,7 +283,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Recv_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             source.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             std::addressof(mpi_request));
 # else // MPI_VERSION >= 4
@@ -522,7 +522,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Send_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             mpi_request_ptr_);
 # elif MPI_VERSION >= 3
@@ -551,7 +551,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Bsend_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             mpi_request_ptr_);
 # elif MPI_VERSION >= 3
@@ -580,7 +580,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Ssend_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             mpi_request_ptr_);
 # elif MPI_VERSION >= 3
@@ -609,7 +609,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Rsend_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             destination.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             mpi_request_ptr_);
 # elif MPI_VERSION >= 3
@@ -638,7 +638,7 @@ namespace yampi
 # if MPI_VERSION >= 4
       int const error_code
         = MPI_Recv_init_c(
-            buffer.data(), buffer.count(), buffer.datatype().mpi_datatype(),
+            buffer.data(), buffer.count().mpi_count(), buffer.datatype().mpi_datatype(),
             source.mpi_rank(), tag.mpi_tag(), communicator.mpi_comm(),
             mpi_request_ptr_);
 # else // MPI_VERSION >= 4

--- a/include/yampi/reduce.hpp
+++ b/include/yampi/reduce.hpp
@@ -33,7 +33,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to SendValue");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count().mpi_count() <= send_buffer.data());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + send_buffer.count() <= send_buffer.data());
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code

--- a/include/yampi/reduce_scatter.hpp
+++ b/include/yampi/reduce_scatter.hpp
@@ -30,8 +30,13 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          SendValue>::value),
       "value_type of ContiguousIterator must be the same to Value");
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= std::addressof(*first) or std::addressof(*first) + 1 <= send_buffer.data());
+    assert(send_buffer.count().mpi_count() == communicator.size(environment));
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= std::addressof(*first) or std::addressof(*first) + 1 <= send_buffer.data());
     assert(send_buffer.count() == communicator.size(environment));
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -59,8 +64,13 @@ namespace yampi
     ::yampi::binary_operation const& operation,
     ::yampi::communicator_base const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data());
+    assert(send_buffer.count().mpi_count() == communicator.size(environment) * receive_buffer.count().mpi_count());
+# else // MPI_VERSION >= 4
     assert(send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data());
     assert(send_buffer.count() == communicator.size(environment) * receive_buffer.count());
+# endif // MPI_VERSION >= 4
     assert(send_buffer.datatype() == receive_buffer.datatype());
 
 # if MPI_VERSION >= 4

--- a/include/yampi/scatter.hpp
+++ b/include/yampi/scatter.hpp
@@ -31,7 +31,11 @@ namespace yampi
          typename std::iterator_traits<ContiguousIterator>::value_type,
          ReceiveValue>::value),
       "value_type of ContiguousIterator must be the same to ReceiveValue");
+# if MPI_VERSION >= 4
+    assert(communicator.rank(environment) != root or (std::addressof(*first) + receive_buffer.count().mpi_count() * communicator.size(environment) <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= std::addressof(*first)));
+# else // MPI_VERSION >= 4
     assert(communicator.rank(environment) != root or (std::addressof(*first) + receive_buffer.count() * communicator.size(environment) <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= std::addressof(*first)));
+# endif // MPI_VERSION >= 4
 
 # if MPI_VERSION >= 4
     auto const error_code
@@ -55,7 +59,11 @@ namespace yampi
     ::yampi::buffer<SendValue> const send_buffer, ::yampi::buffer<ReceiveValue> receive_buffer, ::yampi::rank const root,
     ::yampi::communicator const& communicator, ::yampi::environment const& environment)
   {
+# if MPI_VERSION >= 4
+    assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count().mpi_count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count().mpi_count() <= send_buffer.data()));
+# else // MPI_VERSION >= 4
     assert(communicator.rank(environment) != root or (send_buffer.data() + send_buffer.count() <= receive_buffer.data() or receive_buffer.data() + receive_buffer.count() <= send_buffer.data()));
+# endif // MPI_VERSION >= 4
 
     auto const size = communicator.size(environment);
     auto const send_count = send_buffer.count() / size;


### PR DESCRIPTION
Fix the following bugs:

- constructors in `yampi::extent` could be invalid if `MPI_Count` is just an alias of `MPI_Aint`
- MPI4 version of `yampi::binary_operation::reset` was not defined
- `MPI_Get_info_string` was incorrectly called in `yampi::information::at`
- MPI4 version of `yampi::buffer::count` was incorrectly used when algorithm functions are called such as `std::xxx(buffer.data(), buffer.data() + buffer.count(), ...)` (the return type of `yampi::buffer::count` is `yampi::count` in the case of MPI4, and it cannot be converted to any integer types implicitly)